### PR TITLE
헤일러 - 2주차 제출(재귀, 분할 정복)

### DIFF
--- a/헤일러/2주차/BOJ/BOJ1023.java
+++ b/헤일러/2주차/BOJ/BOJ1023.java
@@ -1,0 +1,74 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+// https://www.acmicpc.net/problem/1023
+// 괄호 문자열
+public class BOJ1023 {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    static int N;
+    static long[][] po;
+    static char[] ans;
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        long K = Long.parseLong(st.nextToken());
+
+        // po[len][cntOpen] = 괄호 문자열이 될 가능성이 있고, 길이가 len이면서, (의 개수가 cntOpen개 남는 문자열.
+        po = new long[N + 1][N + 2];
+        ans = new char[N + 1];
+
+        po[0][0] = 1;
+        for (int len = 1; len <= N; len++) {
+            po[len][0] = po[len - 1][1];
+            for (int cntOpen = 1; cntOpen < N; cntOpen++) {
+                po[len][cntOpen] = po[len - 1][cntOpen - 1] + po[len - 1][cntOpen + 1];
+            }
+            po[len][N] = po[len - 1][N - 1];
+        }
+        long impoSum = (1L << N) - po[N][0];
+        if (impoSum <= K) {
+            System.out.println("-1");
+            return;
+        }
+
+        solve(0, N, 0, K, true);
+
+        for (int i = 0; i < N; i++) {
+            bw.write(ans[i]);
+        }
+        bw.flush();
+    }
+
+    // isPossible: 아직 올바른 괄호 문자열이 될 가능성이 있으면 true
+    private static void solve(int idx, int leftLen, int cntOpen, long leftK, boolean isPossible) {
+        if (idx == N) {
+            return;
+        }
+
+        // cnt = idx에 (를 고정했을 때, 괄호 ㄴㄴ 문자열 개수
+        long cnt = (1L << (leftLen - 1));
+        if (isPossible) {
+            cnt -= po[leftLen - 1][cntOpen + 1];
+        }
+
+        if (leftK < cnt) {
+            ans[idx] = '(';
+            solve(idx + 1, leftLen - 1, cntOpen + 1, leftK, isPossible);
+        } else {
+            ans[idx] = ')';
+            if (cntOpen - 1 < 0) {
+                isPossible = false;
+            }
+            solve(idx + 1, leftLen - 1, cntOpen - 1, leftK - cnt, isPossible);
+        }
+    }
+}

--- a/헤일러/2주차/BOJ/BOJ1023.java
+++ b/헤일러/2주차/BOJ/BOJ1023.java
@@ -40,7 +40,7 @@ public class BOJ1023 {
             return;
         }
 
-        solve(0, N, 0, K, true);
+        solve(0, 0, K, true);
 
         for (int i = 0; i < N; i++) {
             bw.write(ans[i]);
@@ -49,12 +49,13 @@ public class BOJ1023 {
     }
 
     // isPossible: 아직 올바른 괄호 문자열이 될 가능성이 있으면 true
-    private static void solve(int idx, int leftLen, int cntOpen, long leftK, boolean isPossible) {
+    private static void solve(int idx, int cntOpen, long leftK, boolean isPossible) {
         if (idx == N) {
             return;
         }
 
         // cnt = idx에 (를 고정했을 때, 괄호 ㄴㄴ 문자열 개수
+        int leftLen = N - idx;
         long cnt = (1L << (leftLen - 1));
         if (isPossible) {
             cnt -= po[leftLen - 1][cntOpen + 1];
@@ -62,13 +63,13 @@ public class BOJ1023 {
 
         if (leftK < cnt) {
             ans[idx] = '(';
-            solve(idx + 1, leftLen - 1, cntOpen + 1, leftK, isPossible);
+            solve(idx + 1, cntOpen + 1, leftK, isPossible);
         } else {
             ans[idx] = ')';
             if (cntOpen - 1 < 0) {
                 isPossible = false;
             }
-            solve(idx + 1, leftLen - 1, cntOpen - 1, leftK - cnt, isPossible);
+            solve(idx + 1, cntOpen - 1, leftK - cnt, isPossible);
         }
     }
 }

--- a/헤일러/2주차/BOJ/BOJ11729.java
+++ b/헤일러/2주차/BOJ/BOJ11729.java
@@ -1,0 +1,31 @@
+import java.io.*;
+
+// https://www.acmicpc.net/problem/11729
+// 하노이 탑 이동 순서
+// println은 매우 느리다. 출력을 나누어 해야할 때는 무조건 BufferedWriter를 사용할 것.
+public class BOJ11729 {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static int cnt = 0;
+
+
+    static void dfs(int n, int src, int mid, int dst) throws IOException {
+        if(n == 1) {
+            bw.write(String.format("%d %d\n", src, dst));
+            return;
+        }
+        dfs(n-1, src, dst, mid);
+        bw.write(String.format("%d %d\n", src, dst));
+        dfs(n-1, mid, src, dst);
+
+    }
+
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+        bw.write(String.format("%d\n", (1<<N)-1));
+
+        dfs(N, 1, 2, 3);
+        bw.flush();
+    }
+}

--- a/헤일러/2주차/BOJ/BOJ1967.java
+++ b/헤일러/2주차/BOJ/BOJ1967.java
@@ -1,0 +1,87 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class BOJ1967 {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        @SuppressWarnings("unchecked")
+        List<Edge>[] graph = new ArrayList[n + 1];
+
+        for (int i = 0; i <= n; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+
+            graph[u].add(new Edge(v, w));
+            graph[v].add(new Edge(u, w));
+        }
+
+        boolean[] visited = new boolean[n + 1];
+        int[] distance = new int[n + 1];
+        // 지름 노드 1개 탐색
+        calcDistances(1,
+                visited, distance, graph);
+        int maxIdx = 1;
+        for (int i = 2; i <= n; i++) {
+            if (distance[maxIdx] < distance[i]) {
+                maxIdx = i;
+            }
+        }
+
+        // 나머지 1개 탐색
+        Arrays.fill(visited, 1, n + 1, false);
+        Arrays.fill(distance, 1, n + 1, 0);
+        calcDistances(maxIdx,
+                visited, distance, graph);
+        int ans = Arrays.stream(distance)
+                .max()
+                .getAsInt();
+
+        bw.write(String.format("%d", ans));
+        bw.flush();
+    }
+
+    private static void calcDistances(int idx,
+                                      boolean[] visited, int[] distance, List<Edge>[] graph) {
+        if (visited[idx]) {
+            return;
+        }
+
+        visited[idx] = true;
+        for (Edge nextEdge : graph[idx]) {
+            if (visited[nextEdge.to]) {
+                continue;
+            }
+            distance[nextEdge.to] = distance[idx] + nextEdge.w;
+            calcDistances(nextEdge.to,
+                    visited, distance, graph);
+        }
+    }
+
+    static class Edge {
+        int to;
+        int w; // < 100
+
+        public Edge(int to, int w) {
+            this.to = to;
+            this.w = w;
+        }
+    }
+}

--- a/헤일러/2주차/BOJ/BOJ1967.java
+++ b/헤일러/2주차/BOJ/BOJ1967.java
@@ -8,6 +8,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.StringTokenizer;
 
+// https://www.acmicpc.net/problem/1967
+// 트리의 지름
 public class BOJ1967 {
 
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/헤일러/2주차/BOJ/BOJ1992.java
+++ b/헤일러/2주차/BOJ/BOJ1992.java
@@ -1,0 +1,58 @@
+import java.io.*;
+import java.util.*;
+
+// https://www.acmicpc.net/problem/1992
+// 쿼드트리
+public class BOJ1992 {
+
+  static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+  static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+  static StringTokenizer st;
+
+  static void solve(int r, int c, int width, final int[][] sum, final int[][] A) throws IOException{
+    if(width == 1) {
+      if(A[r][c]==1) bw.write("1");
+      else bw.write("0");
+      return;
+    }
+
+    int cnt1 = sum[r+width-1][c+width-1] - (sum[r-1][c+width-1] + sum[r+width-1][c-1]) + sum[r-1][c-1];
+    if(cnt1 == width*width) {
+      bw.write("1");
+      return;
+    } else if(cnt1 == 0) {
+      bw.write("0");
+      return;
+    }
+
+    bw.write("(");
+    solve(r, c, width/2, sum, A);
+    solve(r, c+width/2, width/2, sum, A);
+    solve(r+width/2, c, width/2, sum, A);
+    solve(r+width/2, c+width/2, width/2, sum, A);
+    bw.write(")");
+  }
+
+  public static void main(String[] args) throws IOException {
+    int N = Integer.parseInt(br.readLine());
+
+    int[][] A = new int[N+1][N+1];
+    int[][] sum = new int[N+1][N+1];
+
+    for(int i=1; i<=N; i++) {
+      String row = br.readLine();
+      for(int j=1; j<=N; j++) {
+         A[i][j] = row.charAt(j-1) - '0';
+      }
+    }
+
+    for(int i=1; i<=N; i++) {
+      for(int j=1; j<=N; j++) {
+        sum[i][j] = sum[i-1][j] + sum[i][j-1] - sum[i-1][j-1] + A[i][j];
+      }
+    }
+
+    solve(1, 1, N, sum, A);
+    bw.flush();
+  }
+}

--- a/헤일러/2주차/BOJ/BOJ2250.java
+++ b/헤일러/2주차/BOJ/BOJ2250.java
@@ -1,0 +1,105 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+
+// https://www.acmicpc.net/problem/2250
+// 트리의 높이와 너비
+public class BOJ2250 {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    static int MAXN = 10_000;
+    static int colCnt = 0;
+    static int[] colIdx = new int[MAXN + 1];
+    static int[] level = new int[MAXN + 1];
+
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+        @SuppressWarnings("unchecked")
+        List<Integer>[] graph = new ArrayList[N + 1];
+
+        for (int i = 0; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        boolean[] hasParent = new boolean[N + 1];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int idx = Integer.parseInt(st.nextToken());
+            int lidx = Integer.parseInt(st.nextToken());
+            int ridx = Integer.parseInt(st.nextToken());
+
+            graph[idx].add(lidx);
+            graph[idx].add(ridx);
+
+            if (lidx != -1) {
+                hasParent[lidx] = true;
+            }
+            if (ridx != -1) {
+                hasParent[ridx] = true;
+            }
+        }
+
+        // find root
+        int root = 1;
+        for (int i = 1; i <= N; i++) {
+            if (!hasParent[i]) {
+                root = i;
+                break;
+            }
+        }
+
+        // calculate level, colIdx
+        dfs(root, 1, graph);
+
+        // 레벨 별 가장 좌측, 우측 합 계산
+        int[] minleftSum = new int[N + 1];
+        int[] minRightSum = new int[N + 1];
+        Arrays.fill(minleftSum, 0, N + 1, Integer.MAX_VALUE);
+        Arrays.fill(minRightSum, 0, N + 1, Integer.MAX_VALUE);
+
+        int maxLevel = 1;
+        for (int i = 1; i <= N; i++) {
+            minleftSum[level[i]] = Math.min(minleftSum[level[i]], colIdx[i] - 1);
+            minRightSum[level[i]] = Math.min(minRightSum[level[i]], N - colIdx[i]);
+
+            maxLevel = Math.max(maxLevel, level[i]);
+        }
+        
+        int ansLevel = 1;
+        int maxWidth = N - (minleftSum[1] + minRightSum[1]);
+        for (int lv = 2; lv <= maxLevel; lv++) {
+            int width = N - (minleftSum[lv] + minRightSum[lv]);
+            if (width > maxWidth) {
+                ansLevel = lv;
+                maxWidth = width;
+            }
+        }
+
+        bw.write(String.format("%d %d", ansLevel, maxWidth));
+        bw.flush();
+    }
+
+    static void dfs(int idx, int lv,
+                    final List<Integer>[] graph) {
+        if (idx == -1) {
+            return;
+        }
+        level[idx] = lv;
+
+        int lidx = graph[idx].get(0);
+        int ridx = graph[idx].get(1);
+
+        dfs(lidx, lv + 1, graph);
+        colIdx[idx] = ++colCnt;
+        dfs(ridx, lv + 1, graph);
+    }
+}

--- a/헤일러/2주차/BOJ/BOJ2630.java
+++ b/헤일러/2주차/BOJ/BOJ2630.java
@@ -1,0 +1,59 @@
+import java.io.*;
+import java.util.*;
+
+//https://www.acmicpc.net/problem/2630
+//색종이 만들기
+public class BOJ2630 {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int ans0 = 0;
+    static int ans1 = 0;
+
+    static void solve(int r, int c, int width, final int[][] sum, final int[][] A) {
+        if(width == 1) {
+            if(A[r][c] == 0) ans0++;
+            else ans1++;
+            return;
+        }
+
+        // (r, c) ~ (r+width-1, c+width-1)
+        int cnt1 = sum[r+width-1][c+width-1] - (sum[r-1][c+width-1] + sum[r+width-1][c-1]) + sum[r-1][c-1];
+        if(cnt1 == width*width) {
+            ans1++;
+            return;
+        } else if(cnt1 == 0) {
+            ans0++;
+            return;
+        }
+
+        solve(r, c, width/2, sum, A);
+        solve(r+width/2, c, width/2, sum, A);
+        solve(r, c+width/2, width/2, sum, A);
+        solve(r+width/2, c+width/2, width/2, sum, A);
+    }
+
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+
+        int[][] A = new int[N+1][N+1];
+        int[][] sum = new int[N+1][N+1];
+
+        for(int i=1; i<=N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for(int j=1; j<=N; j++) {
+                A[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        for(int i=1; i<=N; i++) {
+            for(int j=1; j<=N; j++) {
+                sum[i][j] = sum[i-1][j] + sum[i][j-1] - sum[i-1][j-1] + A[i][j];
+            }
+        }
+        solve(1, 1, N, sum, A);
+        bw.write(String.format("%d\n%d", ans0, ans1));
+        bw.flush();
+    }
+}


### PR DESCRIPTION
# 푼 문제

## 재귀
- [BOJ11729 - 하노이 탑 이동 순서](https://www.acmicpc.net/problem/11729)

## 분할 정복
- [BOJ2630 - 색종이 만들기](https://www.acmicpc.net/problem/2630)
- [BOJ1992 - 쿼드트리](https://www.acmicpc.net/problem/1992)
- [BOJ2250 - 트리의 높이와 너비](https://www.acmicpc.net/problem/2250)
- [BOJ1967 - 트리의 지름](https://www.acmicpc.net/problem/1967)

## DP
- [BOJ1023 - 괄호 문자열](https://www.acmicpc.net/problem/1023)
  - k번째 수

# 배운 점
- `println`은 매우 느리다. 출력을 여러 번 나누어 해야 할 때는 무조건 `BufferedWriter`를 사용할 것
- `BufferedReader`, `BufferedWrtier`, `StringTokenizer`는 항상 사용되는 객체이므로 static으로 선언하지 않을 이유가 없어보임
- Java 언어에서 인접리스트로 그래프를 표현하는 방법1: 리스트의 배열
```java
int N = Integer.parseInt(br.readLine());
@SuppressWarnings("unchecked")
List<Integer>[] graph = new ArrayList[N + 1];

for (int i = 0; i <= N; i++) {
    graph[i] = new ArrayList<>();
}
...
graph[u].add(v);
```