### PR TITLE
헤일러 - 6주차 제출(Greedy)

### DIFF
--- a/헤일러/4주차/BOJ2178.java
+++ b/헤일러/4주차/BOJ2178.java
@@ -1,0 +1,88 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.StringTokenizer;
+
+
+// https://www.acmicpc.net/problem/2178
+// 미로 탐색
+public class Main {
+
+    static final int MAXN = 100;
+    static final int MAXM = 100;
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    private static int WALL = 0;
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        List<String> inp = new ArrayList<>();
+        for (int i = 0; i < N; i++) {
+            String s = br.readLine();
+            inp.add(s);
+        }
+        int[][] board = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                board[i][j] = inp.get(i).charAt(j) - '0';
+            }
+        }
+
+        boolean[][] visited = new boolean[MAXN][MAXM];
+        int[][] step = new int[MAXN][MAXM];
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                step[i][j] = -1;
+            }
+        }
+
+        int dr[] = {-1, 1, 0, 0};
+        int dc[] = {0, 0, -1, 1};
+
+        Deque<Node> dq = new ArrayDeque<>();
+        dq.addLast(new Node(0, 0));
+        step[0][0] = 0;
+        while (!dq.isEmpty()) {
+            Node cur = dq.pollFirst();
+
+            for (int d = 0; d < 4; d++) {
+                int nr = dr[d] + cur.r;
+                int nc = dc[d] + cur.c;
+                if (!(isIn(0, N - 1, nr) && isIn(0, M - 1, nc))
+                        || board[nr][nc] == WALL
+                        || step[nr][nc] != -1
+                ) {
+                    continue;
+                }
+                step[nr][nc] = step[cur.r][cur.c] + 1;
+                dq.addLast(new Node(nr, nc));
+            }
+        }
+        bw.write(String.valueOf(step[N - 1][M - 1] + 1));
+        bw.flush();
+    }
+
+    static boolean isIn(int st, int ed, int x) {
+        return !(x < st || x > ed);
+    }
+
+    static class Node {
+        int r;
+        int c;
+
+        public Node(int r, int c) {
+            this.r = r;
+            this.c = c;
+        }
+    }
+}

--- a/헤일러/6주차/BOJ10800.java
+++ b/헤일러/6주차/BOJ10800.java
@@ -1,0 +1,72 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+// https://www.acmicpc.net/problem/10800
+// 컬러볼
+// 카테고리: 정렬, 누적합, 투 포인터
+public class BOJ10800 {
+
+    static final int MAXC = 200000;
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    static long[] ans = new long[MAXC];
+    static long[] colorSum = new long[MAXC + 1];
+
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+
+        List<Ball> balls = new ArrayList<>();
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int C = Integer.parseInt(st.nextToken());
+            int S = Integer.parseInt(st.nextToken());
+            balls.add(new Ball(i, C, S));
+        }
+        balls.sort((b1, b2) -> b1.size - b2.size);
+
+        long allSum = 0;
+        int j = 0;
+
+        for (int i = 0; i < balls.size(); i++) {
+            Ball current = balls.get(i);
+
+            while (balls.get(j).size < current.size) {
+                Ball prev = balls.get(j);
+                allSum += prev.size;
+                colorSum[prev.color] += prev.size;
+                j++;
+            }
+
+            ans[current.idx] = allSum - colorSum[current.color];
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < N; i++) {
+            sb.append(ans[i]).append("\n");
+        }
+        bw.write(sb.toString());
+        bw.flush();
+    }
+
+    static class Ball {
+        int idx;
+        int color;
+        int size;
+
+        public Ball(int idx, int color, int size) {
+            this.idx = idx;
+            this.color = color;
+            this.size = size;
+        }
+    }
+}

--- a/헤일러/6주차/BOJ10986.java
+++ b/헤일러/6주차/BOJ10986.java
@@ -7,6 +7,7 @@ import java.util.StringTokenizer;
 
 // https://www.acmicpc.net/problem/10986
 // 나머지 합
+// DP
 public class BOJ10986 {
 
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/헤일러/6주차/BOJ10986.java
+++ b/헤일러/6주차/BOJ10986.java
@@ -1,0 +1,40 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+// https://www.acmicpc.net/problem/10986
+// 나머지 합
+public class BOJ10986 {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        int[] A = new int[N + 1];
+        int[] sum = new int[N + 1];
+        int[] remCnt = new int[M];
+
+        long ans = 0;
+        remCnt[0] = 1;
+        
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            A[i] = Integer.parseInt(st.nextToken());
+            sum[i] = (sum[i - 1] + A[i]) % M;
+
+            ans += remCnt[sum[i]];
+            remCnt[sum[i]]++;
+        }
+
+        bw.write(String.valueOf(ans));
+        bw.flush();
+    }
+}

--- a/헤일러/6주차/BOJ10986.java
+++ b/헤일러/6주차/BOJ10986.java
@@ -7,7 +7,7 @@ import java.util.StringTokenizer;
 
 // https://www.acmicpc.net/problem/10986
 // 나머지 합
-// DP
+// 카테고리: DP
 public class BOJ10986 {
 
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/헤일러/6주차/BOJ1120.java
+++ b/헤일러/6주차/BOJ1120.java
@@ -8,7 +8,7 @@ import java.util.StringTokenizer;
 // https://www.acmicpc.net/submit/1120
 // 문자열
 // 카테고리: Greedy
-public class Main {
+public class BOJ1120 {
 
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
     static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));

--- a/헤일러/6주차/BOJ1120.java
+++ b/헤일러/6주차/BOJ1120.java
@@ -1,0 +1,50 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+// https://www.acmicpc.net/submit/1120
+// 문자열
+// 카테고리: Greedy
+public class Main {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        String A = st.nextToken();
+        String B = st.nextToken();
+
+        if (A.length() > B.length()) {
+            String C = A;
+            A = B;
+            B = C;
+        }
+
+        int minDiff = Integer.MAX_VALUE;
+        for (int i = 0; i <= B.length() - A.length(); i++) {
+
+            String subB = B.substring(i, B.length());
+            int diff = calculateDiff(A, subB);
+            minDiff = Math.min(minDiff, diff);
+        }
+
+        bw.write(String.valueOf(minDiff));
+        bw.flush();
+    }
+
+    static int calculateDiff(String a, String b) {
+        int len = Math.min(a.length(), b.length());
+        int diff = 0;
+        for (int i = 0; i < len; i++) {
+            if (a.charAt(i) != b.charAt(i)) {
+                diff++;
+            }
+        }
+        return diff;
+    }
+}

--- a/헤일러/6주차/BOJ1931.java
+++ b/헤일러/6주차/BOJ1931.java
@@ -15,7 +15,6 @@ public class BOJ1931 {
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
     static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
     static StringTokenizer st;
-    static char[][] board = new char[7000][7000];
 
     public static void main(String[] args) throws IOException {
         int N = Integer.parseInt(br.readLine());

--- a/헤일러/6주차/BOJ1931.java
+++ b/헤일러/6주차/BOJ1931.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+// https://www.acmicpc.net/problem/1931
+// 회의실 배정
+public class BOJ1931 {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static char[][] board = new char[7000][7000];
+
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+
+        List<Node> nodes = new ArrayList<>();
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+            nodes.add(new Node(start, end));
+        }
+
+        nodes.sort((n1, n2) -> {
+                    if (n1.end != n2.end) {
+                        return n1.end - n2.end;
+                    }
+                    return n1.start - n2.start;
+                }
+        );
+        int ans = 1;
+        int currentEnd = nodes.get(0).end;
+        for (int i = 1; i < nodes.size(); i++) {
+            Node currentNode = nodes.get(i);
+            if (currentEnd <= currentNode.start) {
+                currentEnd = currentNode.end;
+                ans++;
+            }
+        }
+        bw.write(String.valueOf(ans));
+        bw.flush();
+    }
+
+    static class Node {
+        int start;
+        int end;
+
+        public Node(int start, int end) {
+            this.start = start;
+            this.end = end;
+        }
+    }
+}

--- a/헤일러/6주차/BOJ1931.java
+++ b/헤일러/6주차/BOJ1931.java
@@ -9,6 +9,7 @@ import java.util.StringTokenizer;
 
 // https://www.acmicpc.net/problem/1931
 // 회의실 배정
+// greedy
 public class BOJ1931 {
 
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/헤일러/6주차/BOJ1931.java
+++ b/헤일러/6주차/BOJ1931.java
@@ -9,7 +9,7 @@ import java.util.StringTokenizer;
 
 // https://www.acmicpc.net/problem/1931
 // 회의실 배정
-// greedy
+// 카테고리: Greedy
 public class BOJ1931 {
 
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/헤일러/6주차/BOJ2447.java
+++ b/헤일러/6주차/BOJ2447.java
@@ -8,7 +8,7 @@ import java.util.StringTokenizer;
 // https://www.acmicpc.net/problem/2447
 // 별 찍기 - 10
 // greedy
-public class Main {
+public class BOJ2447 {
 
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
     static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));

--- a/헤일러/6주차/BOJ2447.java
+++ b/헤일러/6주차/BOJ2447.java
@@ -7,6 +7,7 @@ import java.util.StringTokenizer;
 
 // https://www.acmicpc.net/problem/2447
 // 별 찍기 - 10
+// greedy
 public class Main {
 
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/헤일러/6주차/BOJ2447.java
+++ b/헤일러/6주차/BOJ2447.java
@@ -7,7 +7,7 @@ import java.util.StringTokenizer;
 
 // https://www.acmicpc.net/problem/2447
 // 별 찍기 - 10
-// greedy
+// 카테고리: 분할 정복
 public class BOJ2447 {
 
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/헤일러/6주차/BOJ2447.java
+++ b/헤일러/6주차/BOJ2447.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+// https://www.acmicpc.net/problem/2447
+// 별 찍기 - 10
+public class Main {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static char[][] board = new char[7000][7000];
+
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+        int k = calculateK(N);
+        DnC(0, 0, N, k);
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                bw.write(board[i][j] == '*' ? board[i][j] : ' ');
+            }
+            bw.write("\n");
+        }
+        bw.flush();
+    }
+
+    static int calculateK(int N) {
+        int k = 0;
+        while (N > 0) {
+            N /= 3;
+            k++;
+        }
+        return k;
+    }
+
+    static void DnC(int r, int c, int size, int level) {
+        if (level == 0) {
+            board[r][c] = '*';
+            return;
+        }
+
+        int step = size / 3;
+        for (int i = 0; i < 3; i++) {
+            int nr = r + step * i;
+            for (int j = 0; j < 3; j++) {
+                int nc = c + step * j;
+
+                if (i == 1 && j == 1) {
+                    continue;
+                }
+                DnC(nr, nc, size / 3, level - 1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 푼 문제
## Greedy
- [문자열](https://www.acmicpc.net/problem/1120)
- [회의실 배정](https://www.acmicpc.net/problem/1931)
- [컬러볼](https://www.acmicpc.net/problem/10800)

## DP
- [나머지 합](https://www.acmicpc.net/problem/10986)

## 분할 정복
- [별 찍기 - 10](https://www.acmicpc.net/problem/2447)

# 배운 점
- 출력 문자열을 `StringBuilder`에 모아서 한 번에 출력하는 것이 여러 번 write()하는 것보다 훨씬 빠르다. (I/O 시스템 콜 횟수를 줄이므로)
- Java도 C언어와 마찬가지로 전역(static) 배열을 선언하는 것이 로컬에 배열을 선언하는 것보다 초기화가 빠르다. 백준 플랫폼 기준 20만개의 원소를 가진 배열 선언을 static으로 했을 때와 로컬에 했을 때 약 60ms 정도 차이가 났다.

# 다음 목표
- 바쁘면 DP, 안 바쁘면 Union-Find